### PR TITLE
Add inserted sequence for insertions to INFO column

### DIFF
--- a/savana/classify.py
+++ b/savana/classify.py
@@ -27,7 +27,9 @@ def get_info_fields(vcf):
 	fields = []
 	for rec in vcf.header_iter():
 		if rec['HeaderType'] == "INFO":
-			fields.append(rec.info()['ID'])
+			field = rec.info()['ID']
+			if field != 'SVINSSEQ':
+				fields.append(field)
 
 	return fields
 

--- a/savana/core.py
+++ b/savana/core.py
@@ -221,6 +221,7 @@ class ConsensusBreakpoint():
 			info[0] = 'SVTYPE=INS;' + info[0]
 			info[0]+=f'TUMOUR_DP={self.local_depths["tumour"][0]};'
 			info[0]+=f'NORMAL_DP={self.local_depths["normal"][0]};'
+			info[0]+=f'SVINSSEQ={self.inserted_sequence};'
 		else:
 			info.append(info[0]) # duplicate info
 			# add edge-specific info

--- a/savana/helper.py
+++ b/savana/helper.py
@@ -289,7 +289,8 @@ def generate_vcf_header(args, example_breakpoint):
 		'##INFO=<ID=END_CLUSTER,Number=.,Type=String,Description="SAVANA internal end cluster id supporting variant">',
 		'##INFO=<ID=TUMOUR_DP,Number=.,Type=Float,Description="Local depth in tumour at the breakpoint(s) of an SV">',
 		'##INFO=<ID=NORMAL_DP,Number=.,Type=Float,Description="Local depth in normal at the breakpoint(s) of an SV">',
-		'##INFO=<ID=BP_NOTATION,Number=1,Type=String,Description="+- notation format of variant (same for paired breakpoints)">'
+		'##INFO=<ID=BP_NOTATION,Number=1,Type=String,Description="+- notation format of variant (same for paired breakpoints)">',
+		'##INFO=<ID=SVINSSEQ,Number=1,Type=String,Description="Longest insert sequence detected for an insertion, including an insert from a normal read if there is support for one at the location">'
 	])
 	# add the stat info fields
 	breakpoint_stats_origin = example_breakpoint.originating_cluster.get_stats().keys()


### PR DESCRIPTION
The inserted sequence corresponds to the longest insert in that location, even if it comes from a CONTROL read.

This is a temporary workaround. I final solution will be provided by the author of SAVANA, that will output the insertion sequence to a fasta file, to be referenced in the vcf. This to avoid cluttering the vcf file with long insertion sequences.